### PR TITLE
Add/platform override support

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,36 @@ A list of export locations to be used to share build cache with future builds in
 
 They will be mapped directly to `cache-to` elements in the build according to the spec so any valid format there should be allowed.
 
+#### `platforms` (build only, string or array)
+
+A list of target platforms to build for when creating multi-architecture images. This option overrides any platforms specified in your docker-compose file and is particularly useful for multi-arch builds using buildx.
+
+Platforms are specified in the format `os/architecture[/variant]`, for example:
+
+- `linux/amd64`
+- `linux/arm64`
+- `linux/arm/v7`
+
+When multiple platforms are specified, the build will create a multi-architecture image manifest. This requires using a builder with the `docker-container` or `remote` driver, and typically requires the `push-on-build: true` option since multi-platform images cannot be loaded into the local Docker daemon.
+
+Example:
+
+```yaml
+steps:
+  - label: "Build multi-arch image"
+    plugins:
+      - docker-compose#v5.0.0:
+          build: app
+          push: app:myregistry/myapp:latest
+          platforms:
+            - linux/amd64
+            - linux/arm64
+          builder:
+            create: true
+            driver: docker-container
+            push-on-build: true
+```
+
 #### `target` (build only)
 
 Allow for intermediate builds as if building with Docker's `--target VALUE` options.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,11 @@ Platforms are specified in the format `os/architecture[/variant]`, for example:
 - `linux/arm64`
 - `linux/arm/v7`
 
-When multiple platforms are specified, the build will create a multi-architecture image manifest. This requires using a builder with the `docker-container` or `remote` driver, and typically requires the `push-on-build: true` option since multi-platform images cannot be loaded into the local Docker daemon.
+**Important**: Multi-platform images cannot be loaded into the local Docker daemon and must be pushed directly to a registry. When platforms are specified:
+
+- You **must** also configure `push` targets with registry locations
+- The plugin automatically enables push-on-build behavior
+- A builder with the `docker-container` or `remote` driver is required
 
 Example:
 
@@ -222,7 +226,6 @@ steps:
           builder:
             create: true
             driver: docker-container
-            push-on-build: true
 ```
 
 #### `target` (build only)

--- a/commands/build.sh
+++ b/commands/build.sh
@@ -122,7 +122,12 @@ for service_name in $(plugin_read_list BUILD) ; do
     [[ -n "${label:-}" ]] && labels+=("${label}")
   done <<< "$(plugin_read_list BUILD_LABELS)"
 
-  if [[ -n "${image_name}" ]] || [[ -n "${target}" ]] || [[ "${#labels[@]}" -gt 0 ]] || [[ "${#cache_to[@]}" -gt 0 ]] || [[ "${#cache_from[@]}" -gt 0 ]]; then
+  platforms=()
+  while read -r platform ; do
+    [[ -n "${platform:-}" ]] && platforms+=("${platform}")
+  done <<< "$(plugin_read_list PLATFORMS)"
+
+  if [[ -n "${image_name}" ]] || [[ -n "${target}" ]] || [[ "${#labels[@]}" -gt 0 ]] || [[ "${#cache_to[@]}" -gt 0 ]] || [[ "${#cache_from[@]}" -gt 0 ]] || [[ "${#platforms[@]}" -gt 0 ]]; then
     build_images+=("$service_name" "${image_name}" "${target}")
 
     build_images+=("${#cache_from[@]}")
@@ -138,6 +143,11 @@ for service_name in $(plugin_read_list BUILD) ; do
     build_images+=("${#labels[@]}")
     if [[ "${#labels[@]}" -gt 0 ]]; then
       build_images+=("${labels[@]}")
+    fi
+
+    build_images+=("${#platforms[@]}")
+    if [[ "${#platforms[@]}" -gt 0 ]]; then
+      build_images+=("${platforms[@]}")
     fi
   fi
 done

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -216,7 +216,17 @@ function build_image_override_file_with_version() {
       done
     fi
 
-    if [[ -z "$image_name" ]] && [[ -z "$target" ]] && [[ "$cache_from_amt" -eq 0 ]] && [[ "$cache_to_amt" -eq 0 ]] && [[ "$labels_amt" -eq 0 ]]; then
+    # load platforms array
+    platforms_amt="${1:-0}"
+    [[ -n "${1:-}" ]] && shift; # remove the value if not empty
+    if [[ "${platforms_amt}" -gt 0 ]]; then
+      platforms=()
+      for _ in $(seq 1 "$platforms_amt"); do
+        platforms+=( "$1" ); shift
+      done
+    fi
+
+    if [[ -z "$image_name" ]] && [[ -z "$target" ]] && [[ "$cache_from_amt" -eq 0 ]] && [[ "$cache_to_amt" -eq 0 ]] && [[ "$labels_amt" -eq 0 ]] && [[ "$platforms_amt" -eq 0 ]]; then
       # should not print out an empty service
       continue
     fi
@@ -227,12 +237,19 @@ function build_image_override_file_with_version() {
       printf "    image: %s\\n" "$image_name"
     fi
 
-    if [[ "$cache_from_amt" -gt 0 ]] || [[ "$cache_to_amt" -gt 0 ]] || [[ -n "$target" ]] || [[ "$labels_amt" -gt 0 ]]; then
+    if [[ "$cache_from_amt" -gt 0 ]] || [[ "$cache_to_amt" -gt 0 ]] || [[ -n "$target" ]] || [[ "$labels_amt" -gt 0 ]] || [[ "$platforms_amt" -gt 0 ]]; then
       printf "    build:\\n"
     fi
 
     if [[ -n "$target" ]]; then
       printf "      target: %s\\n" "$target"
+    fi
+
+    if [[ "$platforms_amt" -gt 0 ]] ; then
+      printf "      platforms:\\n"
+      for platform in "${platforms[@]}"; do
+        printf "        - %s\\n" "${platform}"
+      done
     fi
 
     if [[ "$cache_from_amt" -gt 0 ]] ; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -71,6 +71,9 @@ configuration:
     cache-to:
       type: [ string, array ]
       minimum: 1
+    platforms:
+      type: [ string, array ]
+      minimum: 1
     cli-version:
       oneOf:
         - type: string
@@ -202,6 +205,7 @@ configuration:
     buildkit-inline-cache: [ build ]
     cache-from: [ build ]
     cache-to: [ build ]
+    platforms: [ build ]
     command: [ run ]
     dependencies: [ run ]
     entrypoint: [ run ]

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -478,3 +478,40 @@ setup_file() {
   unstub docker
   unstub buildkite-agent
 }
+
+@test "Build with platforms override" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PLATFORMS_0=linux/amd64
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PLATFORMS_1=linux/arm64
+
+  stub docker \
+    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "- linux/amd64"
+  assert_output --partial "- linux/arm64"
+  assert_output --partial "built helloworld"
+
+  unstub docker
+}
+
+@test "Build with single platform override" {
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG="tests/composefiles/docker-compose.v3.2.yml"
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_BUILD_0=helloworld
+  export BUILDKITE_PLUGIN_DOCKER_COMPOSE_PLATFORMS=linux/amd64
+
+  stub docker \
+    "compose -f tests/composefiles/docker-compose.v3.2.yml -p buildkite1111 -f docker-compose.buildkite-1-override.yml build --pull helloworld : echo built helloworld"
+
+  run "$PWD"/hooks/command
+
+  assert_success
+  assert_output --partial "platforms:"
+  assert_output --partial "- linux/amd64"
+  assert_output --partial "built helloworld"
+
+  unstub docker
+}


### PR DESCRIPTION
Instead of needing to specify the platform in the applications docker-compose file, we can use this plugin to create an override to include that.
By including the buildx plugin, it will now export the environment variable that specifies the amd64 and arm64 platforms automatically. 
